### PR TITLE
更新b站消息schema，修复大航海掉落

### DIFF
--- a/VTS_XYPlugin/Bilibili.cs
+++ b/VTS_XYPlugin/Bilibili.cs
@@ -108,7 +108,7 @@ namespace VTS_XYPlugin
         {
             var message = new BGiftMessage()
             {
-                用户ID = sendGift.uid.ToString(),
+                用户ID = sendGift.openId.ToString(),
                 用户名 = sendGift.userName,
                 礼物名 = sendGift.giftName,
                 礼物数量 = (int)sendGift.giftNum,
@@ -124,7 +124,7 @@ namespace VTS_XYPlugin
         {
             var message = new BDanMuMessage()
             {
-                用户ID = dm.uid.ToString(),
+                用户ID = dm.openId.ToString(),
                 用户名 = dm.userName,
                 舰队类型 = dm.guardLevel.ToString().ToJianDuiType(),
                 粉丝牌名称 = dm.fansMedalName,
@@ -138,7 +138,7 @@ namespace VTS_XYPlugin
         {
             var message = new BSCMessage()
             {
-                用户ID = sc.uid.ToString(),
+                用户ID = sc.openId.ToString(),
                 用户名 = sc.userName,
                 金额 = (int)sc.rmb,
                 持续时间 = (int)(sc.endTime - sc.startTime),
@@ -151,7 +151,7 @@ namespace VTS_XYPlugin
         {
             var message = new BBuyJianDuiMessage()
             {
-                用户ID = guard.userInfo.uid.ToString(),
+                用户ID = guard.userInfo.openId.ToString(),
                 用户名 = guard.userInfo.userName,
                 开通类型 = guard.guardLevel.ToString().ToJianDuiType(),
                 开通数量 = (int)guard.guardNum,

--- a/VTS_XYPlugin/Component/XYDropItemBehaviour.cs
+++ b/VTS_XYPlugin/Component/XYDropItemBehaviour.cs
@@ -42,12 +42,12 @@ namespace VTS_XYPlugin
         public virtual void 当收到舰长(object obj)
         {
             BBuyJianDuiMessage message = (BBuyJianDuiMessage)obj;
-            XYLog.LogMessage($"收到了舰队 {message.舰长类型}");
-            var dict = XYDropManager.Instance.SearchDropItemByTriggerGift(message.舰长类型.ToString());
+            XYLog.LogMessage($"收到了舰队 {message.开通类型}");
+            var dict = XYDropManager.Instance.SearchDropItemByTriggerGift(message.开通类型.ToString());
             foreach (var kv in dict)
             {
                 var data = kv.Value;
-                XYLog.LogMessage($"因收到了舰队 {message.舰长类型} 开始掉落 {data.Name}");
+                XYLog.LogMessage($"因收到了舰队 {message.开通类型} 开始掉落 {data.Name}");
                 XYDropManager.Instance.StartDrop(data, 1, message.用户ID);
             }
         }

--- a/VTS_XYPlugin_Common/BLiveOpen/Dm.cs
+++ b/VTS_XYPlugin_Common/BLiveOpen/Dm.cs
@@ -10,9 +10,14 @@ namespace OpenBLive.Runtime.Data
     public struct Dm
     {
         /// <summary>
-        /// 用户UID
+        /// 用户UID(已作废)
         /// </summary>
         [JsonProperty("uid")] public long uid;
+
+        /// <summary>
+        /// open_jd
+        /// </summary>
+        [JsonProperty("open_id")] public string openId;
 
         /// <summary>
         /// 用户昵称

--- a/VTS_XYPlugin_Common/BLiveOpen/Guard.cs
+++ b/VTS_XYPlugin_Common/BLiveOpen/Guard.cs
@@ -20,7 +20,7 @@ namespace OpenBLive.Runtime.Data
         [JsonProperty("guard_num")] public long guardNum;
 
         /// <summary>
-        /// 大航海单位 "月"
+        /// 大航海单位(正常单位为“月”，如为其他内容，无视guard_num以本字段内容为准，例如*3天)
         /// </summary>
         [JsonProperty("guard_unit")] public string guardUnit;
 

--- a/VTS_XYPlugin_Common/BLiveOpen/SendGift.cs
+++ b/VTS_XYPlugin_Common/BLiveOpen/SendGift.cs
@@ -15,9 +15,14 @@ namespace OpenBLive.Runtime.Data
         [JsonProperty("room_id")] public long roomId;
 
         /// <summary>
-        /// 送礼用户UID
+        /// 用户UID(已作废)
         /// </summary>
         [JsonProperty("uid")] public long uid;
+
+        /// <summary>
+        /// open_jd
+        /// </summary>
+        [JsonProperty("open_id")] public string openId;
 
         /// <summary>
         /// 送礼用户昵称

--- a/VTS_XYPlugin_Common/BLiveOpen/SuperChat.cs
+++ b/VTS_XYPlugin_Common/BLiveOpen/SuperChat.cs
@@ -15,9 +15,14 @@ namespace OpenBLive.Runtime.Data
         [JsonProperty("room_id")] public long roomId;
 
         /// <summary>
-        /// 购买用户UID
+        /// 用户UID(已作废)
         /// </summary>
         [JsonProperty("uid")] public long uid;
+
+        /// <summary>
+        /// open_jd
+        /// </summary>
+        [JsonProperty("open_id")] public string openId;
 
         /// <summary>
         /// 购买的用户昵称

--- a/VTS_XYPlugin_Common/BLiveOpen/UserInfo.cs
+++ b/VTS_XYPlugin_Common/BLiveOpen/UserInfo.cs
@@ -10,9 +10,14 @@ namespace OpenBLive.Runtime.Data
     public struct UserInfo
     {
         /// <summary>
-        /// 购买大航海的用户UID
+        /// 用户UID(已作废)
         /// </summary>
         [JsonProperty("uid")] public long uid;
+
+        /// <summary>
+        /// open_jd
+        /// </summary>
+        [JsonProperty("open_id")] public string openId;
 
         /// <summary>
         /// 购买大航海的用户昵称


### PR DESCRIPTION
+ 修复大航海掉落
+ 更新b站消息schema

b站新的schema去除了uid字段 更新为openId， 同步到当前的schema
修复了收到大航海不掉落的问题